### PR TITLE
We should use Centos that ARM (32) compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 RUN yum update -y && \
     yum install -y wget epel-release && \
     wget http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm && \


### PR DESCRIPTION
The latest edgaras/dlna-torrentbox can't been run on raspberry pi 4 (armv7l), x32.
The reason based on latest Centos 8, has not x32 image version. But Centos 7 has it.

So, docker run raises an error:

>Sending build context to Docker daemon    106kB
>Step 1/8 : FROM centos:latest
>latest: Pulling from library/centos
>no matching manifest for linux/arm/v7 in the manifest list entries
> (stop)

Changing Centos tag from latest to 7 gives ability to build own image in arm/v7 computer well.